### PR TITLE
Shooter Status Light

### DIFF
--- a/src/org/usfirst/frc/team4028/robot/subsystems/Shooter.java
+++ b/src/org/usfirst/frc/team4028/robot/subsystems/Shooter.java
@@ -655,6 +655,9 @@ public class Shooter {
 		
 		SmartDashboard.putString("ShooterTable", currentShooterTableValues);
 		SmartDashboard.putString("Distance", _currentShooterTableEntry.Description);
+		
+		// Light will come on when the shooter is turned on. To keep Mikey from running it the whole match!! :) 
+		SmartDashboard.putBoolean("Is Shooter Running?", _isShooterMotorsReentrantRunning);
 	}
 	
 	//============================================================================================


### PR DESCRIPTION
Added a dashboard functionality that shows a green or red light if the
shooter is still running. The primary purpose is to conserve battery.
Still needs to be edited onto the dashboard but code is done. One-line
pull request!!